### PR TITLE
Add shared startup timeout to fiber servers

### DIFF
--- a/backdoors/server.go
+++ b/backdoors/server.go
@@ -5,34 +5,29 @@ import (
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/rs/zerolog/log"
 	"github.com/valkyrie-fnd/valkyrie-stubs/backdoors/evolution"
 	"github.com/valkyrie-fnd/valkyrie-stubs/backdoors/redtiger"
 	"github.com/valkyrie-fnd/valkyrie-stubs/datastore"
+	"github.com/valkyrie-fnd/valkyrie-stubs/utils"
 )
 
 // BackdoorServer creates a new fiber app with the backdoor endpoints. Returns the
 // app and the address it is listening on.
 func BackdoorServer(eds datastore.ExtendedDatastore, addr string) (*fiber.App, string) {
-	app := fiber.New(fiber.Config{
+	app := utils.HangingStart(addr, fiber.Config{
 		DisableStartupMessage: true,
 		Immutable:             true, // since we store values in-memory after handlers have returned
-	})
-
-	app.Post("/backdoors/evolution/sid", evolution.Sid(eds))
-	app.Post("/backdoors/redtiger/session", redtiger.Session(eds))
-	app.Post("/backdoors/datastore/session/reset", func(ctx *fiber.Ctx) error {
-		eds.ClearSessionData()
-		return nil
-	})
-	app.Post("/backdoors/session", Session(eds))
-
-	go func() {
-		err := app.Listen(addr)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to start")
-		}
-	}()
+	},
+		func(app *fiber.App) {
+			app.Post("/backdoors/evolution/sid", evolution.Sid(eds))
+			app.Post("/backdoors/redtiger/session", redtiger.Session(eds))
+			app.Post("/backdoors/datastore/session/reset", func(ctx *fiber.Ctx) error {
+				eds.ClearSessionData()
+				return nil
+			})
+			app.Post("/backdoors/session", Session(eds))
+		},
+	)
 
 	return app, fmt.Sprintf("http://%s/backdoors/", addr)
 }

--- a/genericpam/server.go
+++ b/genericpam/server.go
@@ -2,26 +2,20 @@ package genericpam
 
 import (
 	"github.com/gofiber/fiber/v2"
-	"github.com/rs/zerolog/log"
 
 	"github.com/valkyrie-fnd/valkyrie-stubs/datastore"
+	"github.com/valkyrie-fnd/valkyrie-stubs/utils"
 )
 
 func RunServer(ds datastore.DataStore, config Config) *fiber.App {
-	app := fiber.New(fiber.Config{
+	app := utils.HangingStart(config.Address, fiber.Config{
 		DisableStartupMessage: true,
 		Immutable:             true, // since we store values in-memory after handlers have returned
+	}, func(app *fiber.App) {
+		ConfigureLogging(config.LogConfig)
+		SetUpRoutes(app, ds, config.PamApiKey, config.ProviderTokens)
+
 	})
-
-	ConfigureLogging(config.LogConfig)
-	SetUpRoutes(app, ds, config.PamApiKey, config.ProviderTokens)
-
-	go func() {
-		err := app.Listen(config.Address)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to start")
-		}
-	}()
 
 	return app
 }

--- a/utils/fiber.go
+++ b/utils/fiber.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog/log"
+)
+
+type Routing = func(app *fiber.App)
+
+// waitUntil starts Fiber app and waits until it is ready to accept connections.
+func HangingStart(adr string, cfg fiber.Config, rt Routing) *fiber.App {
+
+	app := fiber.New(cfg)
+
+	// register routes
+	rt(app)
+
+	// register startup listener
+	var wg sync.WaitGroup
+	wg.Add(1)
+	app.Hooks().OnListen(func() error {
+		wg.Done()
+		return nil
+	})
+
+	go func() {
+		err := app.Listen(adr)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to start")
+		}
+	}()
+
+	if err := waitUntil(&wg, 3*time.Second); err != nil {
+		log.Fatal().Err(err).Send()
+	}
+
+	return app
+}
+
+func waitUntil(wg *sync.WaitGroup, timeout time.Duration) error {
+	rdy := make(chan struct{})
+
+	go func() {
+		defer close(rdy)
+		wg.Wait()
+	}()
+
+	select {
+	case <-rdy:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("timeout waiting for fiber app to start")
+	}
+}


### PR DESCRIPTION
On slow hosts listeners might not be up before tests start. This will make sure servers either start or blow up after a timeout