### PR TITLE
Add transaction fetching endpoint

### DIFF
--- a/provider/caleta/api_model.go
+++ b/provider/caleta/api_model.go
@@ -1,0 +1,43 @@
+// Package caleta contains the implementation of the caleta provider stub.
+package caleta
+
+import (
+	"time"
+)
+
+type TransactionResponse struct {
+	RoundTransactions *[]RoundTransaction `json:"transactions,omitempty"`
+	Message           string              `json:"message"`
+	RoundID           string              `json:"round_id"`
+	Code              int                 `json:"code"`
+}
+
+type RoundTransaction struct {
+	CreatedTime  time.Time `json:"created_time"`
+	ClosedTime   time.Time `json:"closed_time"`
+	TxnUUID      string    `json:"txn_uuid"`
+	Payload      Payload   `json:"payload"`
+	ID           int       `json:"id"`
+	RoundID      int       `json:"round_id"`
+	TxnType      int       `json:"txn_type"`
+	Status       int       `json:"status"`
+	CacheEntryID int       `json:"cache_entry_id"`
+	Amount       int       `json:"amount"`
+}
+
+type Payload struct {
+	Bet                      string `json:"bet"`
+	Round                    string `json:"round"`
+	Token                    string `json:"token"`
+	Currency                 string `json:"currency"`
+	GameCode                 string `json:"game_code"`
+	RequestUUID              string `json:"request_uuid"`
+	SupplierUser             string `json:"supplier_user"`
+	TransactionUUID          string `json:"transaction_uuid"`
+	ReferenceTransactionUUID string `json:"reference_transaction_uuid"`
+	GameID                   string `json:"game_id"`
+	JackpotContribution      int    `json:"jackpot_contribution"`
+	Amount                   int    `json:"amount"`
+	RoundClosed              bool   `json:"round_closed"`
+	IsFree                   bool   `json:"is_free"`
+}

--- a/provider/endpoints.go
+++ b/provider/endpoints.go
@@ -1,0 +1,78 @@
+// Package provider provides a stubbed implementation of provider endpoints.
+package provider
+
+import (
+	"context"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/valkyrie-fnd/valkyrie-stubs/provider/caleta"
+	"github.com/valkyrie-fnd/valkyrie-stubs/utils"
+)
+
+type providerEndpointsStubs struct {
+	caletaSignatureVerifier SignatureVerifier
+	cannedTransactions      func() (caleta.TransactionResponse, error)
+}
+
+type Option func(*providerEndpointsStubs)
+
+func Create(ctx context.Context, addr string, options ...Option) {
+	p := &providerEndpointsStubs{
+		caletaSignatureVerifier: func(signature string, payload []byte) error { return nil },
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	app := utils.HangingStart(addr, fiber.Config{
+		DisableStartupMessage: true,
+		Immutable:             true,
+	}, func(app *fiber.App) {
+
+		app.Get("/evo/game/launch", evoGameLaunch())
+		app.Get("/caleta/api/game/url", caletaGameLaunch())
+		app.Get("/caleta/api/transactions/round", caletaGetTransactions(p))
+	})
+
+	go func() {
+		<-ctx.Done()
+		_ = app.Shutdown()
+	}()
+}
+
+func WithCaletaSignatureVerifier(v SignatureVerifier) Option {
+	return func(p *providerEndpointsStubs) {
+		p.caletaSignatureVerifier = v
+	}
+}
+
+func WithCannedTransactions(v func() (caleta.TransactionResponse, error)) Option {
+	return func(p *providerEndpointsStubs) {
+		p.cannedTransactions = v
+	}
+}
+
+func evoGameLaunch() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	}
+}
+
+type SignatureVerifier func(signature string, payload []byte) error
+
+func caletaGameLaunch() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	}
+}
+
+func caletaGetTransactions(p *providerEndpointsStubs) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		t, err := p.cannedTransactions()
+		if err != nil {
+			return err
+		}
+		return c.JSON(t)
+	}
+}

--- a/provider/endpoints_test.go
+++ b/provider/endpoints_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valkyrie-fnd/valkyrie-stubs/provider/caleta"
+	"github.com/valkyrie-fnd/valkyrie-stubs/utils"
+)
+
+func TestCaletaTransactions(t *testing.T) {
+	_, addr, err := utils.GetFreePort()
+	require.NoError(t, err)
+
+	expectedTransactions := func() (caleta.TransactionResponse, error) {
+		return caleta.TransactionResponse{
+			RoundTransactions: &[]caleta.RoundTransaction{
+				{
+					ID: 1,
+				},
+			},
+		}, nil
+	}
+
+	Create(context.TODO(), addr, WithCannedTransactions(expectedTransactions))
+
+	a := fiber.Get(fmt.Sprintf("http://%s/caleta/api/transactions/round", addr))
+	res := caleta.TransactionResponse{}
+	status, body, errs := a.Struct(&res)
+
+	//TODO: use when with Go 1.20
+	// require.NoError(t, errors.Join(errs...))
+	require.Len(t, errs, 0)
+	require.Equal(t, 200, status, string(body))
+	assert.Len(t, *res.RoundTransactions, 1)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -58,19 +58,19 @@ func OrDefault[T any](ptr *T, def T) T {
 }
 
 // GetFreePort returns a free open port that is ready to use.
-func GetFreePort() (int, error) {
+func GetFreePort() (int, string, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	l, err := net.ListenTCP("tcp", addr)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	defer func() {
 		_ = l.Close()
 	}()
-	return l.Addr().(*net.TCPAddr).Port, nil
+	return l.Addr().(*net.TCPAddr).Port, l.Addr().String(), nil
 }


### PR DESCRIPTION
Add a simple endpoint with option to supply canned transaction responses. For use in integration testing of providers who provide transaction fetch

Fixes #17 